### PR TITLE
Fixed A typo in the Recaptcha App service registration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Validator::extend('recaptcha','App\\Validators\\Recaptcha@validate');
+        Validator::extend('recaptcha','App\\Validators\\ReCaptcha@validate');
     }
 
     /**


### PR DESCRIPTION
The typo causes an invalid class error.